### PR TITLE
Add variable to remove non-specified SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
   - `groups`: optional list of groups to be appended to the user's default groups
   - `password`: optional password hash, only set if the user is created in this invocation
   - `sshpubkey`: optional SSH public key to be added to the authorized_keys file
-  - `sshexclusive`: optional, if `True` and `sshpubkey` is specified, removes all other non-specified keys. Otherwise, appends the the key to any existing keys if not already present. Default: `False.
+  - `sshexclusive`: optional, if `True` and `sshpubkey` is specified, removes all other non-specified keys. Otherwise, appends the key to any existing keys if not already present. Default: `False.
   - `require_first_password`: optional, if `True` attempt to force a newly created user to change their password on first login, default `False`.
 - `local_accounts_groups`: A list of dictionaries containing information on the group to be created (default: empty).
   Each item must contain the following fields:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Role Variables
   - `uid`: user-ID (required)
   - `groups`: optional list of groups to be appended to the user's default groups
   - `password`: optional password hash, only set if the user is created in this invocation
-  - `sshpubkey`: optional SSH public key, will be appended to any existing keys if not already present
+  - `sshpubkey`: optional SSH public key to be added to the authorized_keys file
+  - `sshexclusive`: optional, if `True` and `sshpubkey` is specified, removes all other non-specified keys. Otherwise, appends the the key to any existing keys if not already present. Default: `False.
   - `require_first_password`: optional, if `True` attempt to force a newly created user to change their password on first login, default `False`.
 - `local_accounts_groups`: A list of dictionaries containing information on the group to be created (default: empty).
   Each item must contain the following fields:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,8 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+  playbooks:
+    prepare: prepare.yml
 scenario:
   name: default
 verifier:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,7 +10,6 @@
           uid: 1010
           groups: wheel
           sshpubkey: "ssh-rsa XXXXX"
-      # Should have no effect since users don't exist
       local_accounts_delete:
         - user3
         - user4

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,6 +10,13 @@
           uid: 1010
           groups: wheel
           sshpubkey: "ssh-rsa XXXXX"
+        - user: user1
+          uid: 1001
+          sshpubkey: "ssh-rsa new 1001"
+        - user: user2
+          uid: 1002
+          sshpubkey: "ssh-rsa new 1002"
+          sshexclusive: true
       local_accounts_delete:
         - user3
         - user4

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -35,3 +35,6 @@
       - name: user4
         uid: 1004
         key: "ssh-rsa 1004"
+      - name: user5
+        uid: 1005
+        key: "ssh-rsa 1005"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,37 @@
+---
+- name: Create local users
+  hosts: all
+  tasks:
+    - name: create users
+      become: true
+      user:
+        append: true
+        createhome: true
+        name: "{{ item.name }}"
+        state: present
+        uid: "{{ item.uid }}"
+        update_password: on_create
+      with_items: "{{ users }}"
+    - name: set authorized keys
+      become: true
+      become_user: "{{ item.name }}"
+      authorized_key:
+        key: "{{ item.key }}"
+        manage_dir: false
+        state: present
+        user: "{{ item.name }}"
+      with_items: "{{ users }}"
+  vars:
+    users:
+      - name: user1
+        uid: 1001
+        key: "ssh-rsa 1001"
+      - name: user2
+        uid: 1002
+        key: "ssh-rsa 1002"
+      - name: user3
+        uid: 1003
+        key: "ssh-rsa 1003"
+      - name: user4
+        uid: 1004
+        key: "ssh-rsa 1004"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -37,6 +37,12 @@ def test_precreated_users(host):
     assert u.uid == 1002
 
 
+def test_precreated_users(host):
+    u = host.user('user5')
+    assert u.exists
+    assert u.uid == 1005
+
+
 def test_deleted_users(host):
     u = host.user('user3')
     assert not u.exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,3 +26,19 @@ def test_user_bob(host):
     assert f.group == 'bob'
     assert f.mode == 0o600
     assert f.content_string.rstrip() == 'ssh-rsa XXXXX'
+
+
+def test_precreated_users(host):
+    u = host.user('user1')
+    assert u.exists
+    assert u.uid == 1001
+    u = host.user('user2')
+    assert u.exists
+    assert u.uid == 1002
+
+
+def test_deleted_users(host):
+    u = host.user('user3')
+    assert not u.exists
+    u = host.user('user4')
+    assert not u.exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -28,13 +28,31 @@ def test_user_bob(host):
     assert f.content_string.rstrip() == 'ssh-rsa XXXXX'
 
 
-def test_precreated_users(host):
+def test_ssh_non_exclusive(host):
     u = host.user('user1')
     assert u.exists
     assert u.uid == 1001
+
+    f = host.file('/home/user1/.ssh/authorized_keys')
+    assert f.exists
+    assert f.user == 'user1'
+    assert f.group == 'user1'
+    assert f.mode == 0o600
+    keys = [x.rstrip() for x in f.content_string.splitlines()]
+    assert keys == ['ssh-rsa 1001', 'ssh-rsa new 1001']
+
+
+def test_ssh_exclusive(host):
     u = host.user('user2')
     assert u.exists
     assert u.uid == 1002
+
+    f = host.file('/home/user2/.ssh/authorized_keys')
+    assert f.exists
+    assert f.user == 'user2'
+    assert f.group == 'user2'
+    assert f.mode == 0o600
+    assert f.content_string.rstrip() == 'ssh-rsa new 1002'
 
 
 def test_precreated_users(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
   become: true
   become_user: "{{ item.user }}"
   authorized_key:
-    exclusive: false
+    exclusive: "{{ item.sshexclusive | default(false) }}"
     key: "{{ item.sshpubkey }}"
     manage_dir: false
     state: present


### PR DESCRIPTION
This PR exposes the `authorized_keys.exclusive` parameter to this role by adding a new `sshexclusive` optional attribute to the `local_accounts_create` dictionary. If a key is specified and the new variable is set to `True` (False by default), all existing SSH keys are removed in favor of the specified key.

The Molecule tests are also expanded to:

- add a preparation playbook pre-creating local 5 users with keys
- test the deletion of the 2 of the 5 users via the `local_accounts_delete` variable
- test the update of the 2 of the 5 users with new SSH keys with and without removing all the non-specified keys

Proposed tag: `1.1.0`